### PR TITLE
Add catch-all rule to config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,3 +3,4 @@ credentials-file: /Users/[username]/.cloudflared/[tunnel-id].json
 ingress:
   - hostname: [insert your domain here ex bluebubbles.example.com]
     service: http://localhost:1234
+  - service: http_status:404


### PR DESCRIPTION
Hi, Thanks for creating such an awesome app! 

I did find a couple of things that could use updating in the [Cloudflare Proxy with Custom Domain](https://docs.bluebubbles.app/server/advanced/cloudflare-proxy-with-custom-domain)  docs.

According to the Cloudflare docs:

> Configuration files that contain ingress rules must always include a catch-all rule that concludes the file.

There's a few steps that need to be tweaked in that doc but I couldn't find the repo to propose the changes. 

